### PR TITLE
fix torus coeff calls, world size

### DIFF
--- a/src/openmc_cad_adapter/to_cubit_journal.py
+++ b/src/openmc_cad_adapter/to_cubit_journal.py
@@ -416,7 +416,7 @@ def to_cubit_journal(geom, seen=set(), world=None, cells=None, filename=None, to
                 elif surface._type == "sphere":
                     cmds.append( f"sphere redius {surface.coefficients['r']}")
                     ids = emit_get_last_id(ent_type)
-                    move(ids, surface.coefficients['x0'], surface.coefficients['y0'], surface.coefficients['zy0'])
+                    move(ids, surface.coefficients['x0'], surface.coefficients['y0'], surface.coefficients['z0'])
                     pass
                 elif surface._type == "cone":
                     raise NotImplementedError("cone not implemented")
@@ -457,7 +457,7 @@ def to_cubit_journal(geom, seen=set(), world=None, cells=None, filename=None, to
                     move( ids, surface.coefficients['x0'], surface.coefficients['y0'], surface.coefficients['z0'] )
                     return ids
                 elif surface._type == "x-torus":
-                    cmds.append( f"torus major radius {surface.coefficients['r']} minor radius {surface.coefficients['r']}")
+                    cmds.append( f"torus major radius {surface.coefficients['a']} minor radius {surface.coefficients['b']}")
                     ids = emit_get_last_id( ent_type )
                     cmds.append( f"rotate body {{ {ids} }} about y angle 90")
                     if node.side != '-':
@@ -469,7 +469,7 @@ def to_cubit_journal(geom, seen=set(), world=None, cells=None, filename=None, to
                     move( ids, surface.coefficients['x0'], surface.coefficients['y0'], surface.coefficients['z0'] )
                     return ids
                 elif surface._type == "y-torus":
-                    cmds.append( f"torus major radius {surface.coefficients['r']} minor radius {surface.coefficients['r']}")
+                    cmds.append( f"torus major radius {surface.coefficients['a']} minor radius {surface.coefficients['b']}")
                     ids = emit_get_last_id( ent_type )
                     cmds.append( f"rotate body {{ {ids} }} about x angle 90")
                     if node.side != '-':
@@ -480,7 +480,7 @@ def to_cubit_journal(geom, seen=set(), world=None, cells=None, filename=None, to
                         return wid
                     return ids
                 elif surface._type == "z-torus":
-                    cmds.append( f"torus major radius {surface.coefficients['r']} minor radius {surface.coefficients['r']}")
+                    cmds.append( f"torus major radius {surface.coefficients['a']} minor radius {surface.coefficients['b']}")
                     ids = emit_get_last_id( ent_type )
                     if node.side != '-':
                         cmds.append(f"brick x {w[0]} y {w[1]} z {w[2]}")
@@ -939,7 +939,7 @@ def openmc_to_cad():
                                'Please provide a world size argument to proceed')
         # to ensure that the box
         box_max = np.max(np.abs(bbox[0], bbox[1]).T)
-        world_size = 2*box_maxOA
+        world_size = (2 * box_max, 2 * box_max, 2 * box_max)
     else:
         world_size = args.world_size
 


### PR DESCRIPTION
Ran into a couple issues using the script for toroidal models.

First issue was the script appears to want the world size as an x y z tuple, so for any call to the script that doesn't provide world size args that needed to be fixed.

The second was in reference to the surface coefficients for tori, just a syntax thing really. I will note that the script currently only works for tori with a circular cross section. A more general implementation will require creating an ellipse and sweeping that, but this works for circular cross sections for now.

Fixed a little typo in the sphere surface type as well.