### PR TITLE
Fixed typo causing error with Sphere model

### DIFF
--- a/src/openmc_cad_adapter/gqs.py
+++ b/src/openmc_cad_adapter/gqs.py
@@ -44,7 +44,7 @@ def characterize_general_quadratic( surface ): #s surface
         delta = 0
     else:
         delta = -1 if det_Ac < 0 else -1
-    eigen_results = np.linalg.eig(Aa);
+    eigen_results = np.linalg.eig(Aa)
     signs = np.array([ 0, 0, 0 ])
     for i in range( 0, 3 ):
         if eigen_results.eigenvalues[ i ] > -1 * gq_tol:

--- a/src/openmc_cad_adapter/surfaces.py
+++ b/src/openmc_cad_adapter/surfaces.py
@@ -281,7 +281,7 @@ class CADSphere(CADSurface, openmc.Sphere):
 
     def to_cubit_surface_inner(self, ent_type, node, extents, inner_world=None, hex=False):
         cad_cmds = []
-        cad_cmds.append( f"sphere redius {self.r}")
+        cad_cmds.append( f"sphere radius {self.r}")
         ids = emit_get_last_id(ent_type, cad_cmds)
         move(ids, self.x0, self.y0, self.z0, cad_cmds)
         return ids, cad_cmds

--- a/src/openmc_cad_adapter/to_cubit_journal.py
+++ b/src/openmc_cad_adapter/to_cubit_journal.py
@@ -83,7 +83,7 @@ def to_cubit_journal(geometry : openmc.Geometry, world : Iterable[Real] = None,
                                ' Please provide a world size argument to proceed')
         # to ensure that the box
         box_max = np.max(np.abs(bbox[0], bbox[1]).T)
-        world_size = (2 * box_max, 2 * box_max, 2 * box_max)
+        world = (2 * box_max, 2 * box_max, 2 * box_max)
 
     if world is None:
         raise RuntimeError("Model extents could not be determined automatically and must be provided manually")

--- a/src/openmc_cad_adapter/to_cubit_journal.py
+++ b/src/openmc_cad_adapter/to_cubit_journal.py
@@ -156,7 +156,7 @@ def to_cubit_journal(geometry : openmc.Geometry, world : Iterable[Real] = None,
                             r1 = math.sqrt( abs( -K_/A_ ) )
                             r2 = math.sqrt( abs( -K_/B_ ) )
                             r3 = math.sqrt( abs( -K_/C_ ) )
-                            cmds.append( f"sphere redius 1")
+                            cmds.append( f"sphere radius 1")
                             ids = emit_get_last_id( ent_type , cmds)
                             cmds.append( f"body {{ { ids } }} scale x { r1 } y { r2 } z { r3 }")
                             move( ids, translation[0,0], translation[1,0], translation[2,0], cmds)

--- a/src/openmc_cad_adapter/to_cubit_journal.py
+++ b/src/openmc_cad_adapter/to_cubit_journal.py
@@ -122,19 +122,19 @@ def to_cubit_journal(geometry : openmc.Geometry, world : Iterable[Real] = None,
                     (gq_type, A_, B_, C_, K_, translation, rotation_matrix) = characterize_general_quadratic(surface)
 
                     def rotation_to_axis_angle( mat ):
-                        x = mat[2, 1]-mat[1, 2];
-                        y = mat[0, 2]-mat[2, 0];
-                        z = mat[1, 0]-mat[0, 1];
-                        r = math.hypot( x, math.hypot( y,z ));
-                        t = mat[0,0] + mat[1,1] + mat[2,2];
-                        theta = math.atan2(r,t-1);
+                        x = mat[2, 1]-mat[1, 2]
+                        y = mat[0, 2]-mat[2, 0]
+                        z = mat[1, 0]-mat[0, 1]
+                        r = math.hypot( x, math.hypot( y,z ))
+                        t = mat[0,0] + mat[1,1] + mat[2,2]
+                        theta = math.atan2(r,t-1)
 
                         if abs(theta) <= np.finfo(np.float64).eps:
                             return ( np.array([ 0, 0, 0 ]), 0 )
                         elif abs( theta - math.pi ) <= np.finfo(np.float64).eps:
                           # theta is pi (180 degrees) or extremely close to it
                           # find the column of mat with the largest diagonal
-                          col = 0;
+                          col = 0
                           if mat[1,1] > mat[col,col]: col = 1
                           if mat[2,2] > mat[col,col]: col = 2
 
@@ -403,48 +403,48 @@ def to_cubit_journal(geometry : openmc.Geometry, world : Iterable[Real] = None,
                                 y_pos = 0
                                 r = ring_id
                                 for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
-                                    y_pos = ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter;
+                                    x_pos = x * center_to_mid_side_diameter
+                                    y_pos = ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter
                                     for n, cell in us[k]._cells.items():
                                         draw_hex_cell( n, cell, x_pos, y_pos )
                                     #print( r, k, x, x_pos, y_pos )
                                     k = k + 1
                                     x = x + 1
-                                y_pos = ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter;
+                                y_pos = ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter
                                 for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
+                                    x_pos = x * center_to_mid_side_diameter
                                     for n, cell in us[k]._cells.items():
                                         draw_hex_cell( n, cell, x_pos, y_pos )
                                     #print( r, k, x, x_pos, y_pos )
-                                    y_pos = y_pos - side_to_side_diameter;
+                                    y_pos = y_pos - side_to_side_diameter
                                     k = k + 1
                                 for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
-                                    y_pos = - ring_id * side_to_side_diameter + ( x ) * 0.5 * side_to_side_diameter;
-                                    for n, cell in us[k]._cells.items():
-                                        draw_hex_cell( n, cell, x_pos, y_pos )
-                                    #print( r, k, x, x_pos, y_pos )
-                                    k = k + 1
-                                    x = x - 1
-                                for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
-                                    y_pos = - ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter;
+                                    x_pos = x * center_to_mid_side_diameter
+                                    y_pos = - ring_id * side_to_side_diameter + ( x ) * 0.5 * side_to_side_diameter
                                     for n, cell in us[k]._cells.items():
                                         draw_hex_cell( n, cell, x_pos, y_pos )
                                     #print( r, k, x, x_pos, y_pos )
                                     k = k + 1
                                     x = x - 1
-                                y_pos = - ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter;
                                 for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
+                                    x_pos = x * center_to_mid_side_diameter
+                                    y_pos = - ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter
                                     for n, cell in us[k]._cells.items():
                                         draw_hex_cell( n, cell, x_pos, y_pos )
                                     #print( r, k, x, x_pos, y_pos )
-                                    y_pos = y_pos + side_to_side_diameter;
+                                    k = k + 1
+                                    x = x - 1
+                                y_pos = - ring_id * side_to_side_diameter - ( x ) * 0.5 * side_to_side_diameter
+                                for i in range( r, 0, -1 ):
+                                    x_pos = x * center_to_mid_side_diameter
+                                    for n, cell in us[k]._cells.items():
+                                        draw_hex_cell( n, cell, x_pos, y_pos )
+                                    #print( r, k, x, x_pos, y_pos )
+                                    y_pos = y_pos + side_to_side_diameter
                                     k = k + 1
                                 for i in range( r, 0, -1 ):
-                                    x_pos = x * center_to_mid_side_diameter;
-                                    y_pos = ring_id * side_to_side_diameter + ( x ) * 0.5 * side_to_side_diameter;
+                                    x_pos = x * center_to_mid_side_diameter
+                                    y_pos = ring_id * side_to_side_diameter + ( x ) * 0.5 * side_to_side_diameter
                                     for n, cell in us[k]._cells.items():
                                         draw_hex_cell( n, cell, x_pos, y_pos )
                                     #print( r, k, x, x_pos, y_pos )


### PR DESCRIPTION
I was trying to convert a spherical model to a cubit journal and playback it. I got this error:
![image](https://github.com/user-attachments/assets/c27c28e3-ae50-45b7-b889-b69b1ce006c0)

There was just a typo in a couple of strings "redius" -> "radius".

I also removed some semicolumns that I'm not sure are necessary here, considered the formatting.

Also, I suspect that the `world_size` key should be just `world` in here:

![image](https://github.com/user-attachments/assets/9d341c84-731b-4849-8e1b-a6a99ffe5f62)


but I'm not sure, I ask for confirmation.