### PR TITLE
Missing some imports

### DIFF
--- a/src/openmc_cad_adapter/gqs.py
+++ b/src/openmc_cad_adapter/gqs.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from numpy.linalg import matrix_rank
 
 ELLIPSOID = 1
 ONE_SHEET_HYPERBOLOID = 2

--- a/src/openmc_cad_adapter/to_cubit_journal.py
+++ b/src/openmc_cad_adapter/to_cubit_journal.py
@@ -18,7 +18,22 @@ from openmc.region import Region, Complement, Intersection, Union
 from openmc.surface import Halfspace, Quadric
 from openmc.lattice import Lattice, HexLattice
 
-from .gqs import characterize_general_quadratic
+from .gqs import (
+    characterize_general_quadratic,
+    ELLIPSOID,
+    ONE_SHEET_HYPERBOLOID,
+    TWO_SHEET_HYPERBOLOID,
+    ELLIPTIC_CONE,
+    ELLIPTIC_PARABOLOID,
+    HYPERBOLIC_PARABOLOID,
+    ELLIPTIC_CYLINDER,
+    HYPERBOLIC_CYLINDER,
+    PARABOLIC_CYLINDER
+)
+from .cubit_util import emit_get_last_id, reset_cubit_ids, new_variable
+from .geom_util import rotate, move
+from .cubit_util import emit_get_last_id, reset_cubit_ids, new_variable
+from .geom_util import rotate, move
 from .cubit_util import emit_get_last_id, reset_cubit_ids, new_variable
 from .geom_util import rotate, move
 


### PR DESCRIPTION
Added `from numpy.linalg import matrix_rank ` to `gqs.py` since `characterize_general_quadratic` uses it.
Imported a few constants from `gqs.py` that are used in `to_cubit_journal`. CSG to cubit journal conversion was successful after these changes.

