### PR TITLE
Reset OpenMC IDs between local tests.

### DIFF
--- a/test/gold/cylinder.jou
+++ b/test/gold/cylinder.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 3
+#CELL 1
 cylinder height 500 radius 6.0
 #{ id1 = Id("body") }
 body { id1 } rotate 90.0 about Y
 body { id1 } rotate 45.0 about Z
-body { id1 } name "Cell_3"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/x_cone.jou
+++ b/test/gold/x_cone.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 4
+#CELL 1
 create frustum height 500 radius 50.0 top 0
 #{ id1 = Id("body") }
 rotate body { id1 } about y angle 90
 body { id1 } move 30.0 3.0 5.0
-body { id1 } name "Cell_4"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/x_torus.jou
+++ b/test/gold/x_torus.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 7
+#CELL 1
 torus major radius 5.0 minor radius 2.0
 #{ id1 = Id("body") }
 rotate body { id1 } about y angle 90
 body { id1 } move 10.0 10.0 10.0
-body { id1 } name "Cell_7"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/y_cone.jou
+++ b/test/gold/y_cone.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 5
+#CELL 1
 create frustum height 500 radius 31.622776601683793 top 0
 #{ id1 = Id("body") }
 rotate body { id1 } about x angle 90
 body { id1 } move 40.0 20.0 7.0
-body { id1 } name "Cell_5"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/y_torus.jou
+++ b/test/gold/y_torus.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 8
+#CELL 1
 torus major radius 5.0 minor radius 2.0
 #{ id1 = Id("body") }
 rotate body { id1 } about x angle 90
 body { id1 } move -10.0 -10.0 -10.0
-body { id1 } name "Cell_8"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/ycylinder.jou
+++ b/test/gold/ycylinder.jou
@@ -4,12 +4,12 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 2
+#CELL 1
 cylinder height 500 radius 1.0
 #{ id1 = Id("body") }
 rotate body { id1 } about x angle 90
 body { id1 } move 10.0 0 5.0
-body { id1 } name "Cell_2"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/z_cone.jou
+++ b/test/gold/z_cone.jou
@@ -4,11 +4,11 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 6
+#CELL 1
 create frustum height 500 radius 22.360679774997898 top 0
 #{ id1 = Id("body") }
 body { id1 } move 50.0 10.0 2.0
-body { id1 } name "Cell_6"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/gold/z_torus.jou
+++ b/test/gold/z_torus.jou
@@ -4,11 +4,11 @@ set warning off
 graphics pause
 set journal off
 set default autosize off
-#CELL 9
+#CELL 1
 torus major radius 5.0 minor radius 2.0
 #{ id1 = Id("body") }
 body { id1 } move 50.0 50.0 50.0
-body { id1 } name "Cell_9"
+body { id1 } name "Cell_1"
 group "mat:void" add body { id1 } 
 graphics flush
 set default autosize on

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -1,5 +1,8 @@
-import openmc
+from functools import wraps
+
 import pytest
+
+import openmc
 
 from openmc_cad_adapter import to_cubit_journal
 
@@ -7,6 +10,18 @@ from .test_utilities import diff_gold_file
 from test import run_in_tmpdir
 
 
+def reset_openmc_ids(func):
+    """
+    Decorator to reset the auto-generated IDs in OpenMC before running a test
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        openmc.reset_auto_ids()
+        func(*args, **kwargs)
+    return wrapper
+
+
+@reset_openmc_ids
 def test_planes(request, run_in_tmpdir):
     plane1 = openmc.Plane(A=1.0, B=1.0, C=0.0, D=-5.0)
     plane2 = openmc.Plane(A=1.0, B=1.0, C=0.0, D=5.0)
@@ -18,8 +33,10 @@ def test_planes(request, run_in_tmpdir):
     to_cubit_journal(g, world=(500, 500, 500), filename='plane.jou')
     diff_gold_file('plane.jou')
 
+
 # Test the XCylinder and YCylinder classes, the ZCylinder surface is tested
 # extensively in the OpenMC example tests
+@reset_openmc_ids
 def test_xcylinder(request, run_in_tmpdir):
     x_cyl = openmc.XCylinder(r=1.0, y0=10.0, z0=5.0)
     g = openmc.Geometry([openmc.Cell(region=-x_cyl)])
@@ -27,6 +44,7 @@ def test_xcylinder(request, run_in_tmpdir):
     diff_gold_file('xcylinder.jou')
 
 
+@reset_openmc_ids
 def test_ycylinder(request, run_in_tmpdir):
     y_cyl = openmc.YCylinder(r=1.0, x0=10.0, z0=5.0)
     g = openmc.Geometry([openmc.Cell(region=-y_cyl)])
@@ -34,6 +52,7 @@ def test_ycylinder(request, run_in_tmpdir):
     diff_gold_file('ycylinder.jou')
 
 
+@reset_openmc_ids
 def test_cylinder(request, run_in_tmpdir):
     cyl = openmc.Cylinder(x0=0.0, y0=0.0, z0=0.0, r=6.0, dx=0.7071, dy=0.7071, dz=0.0)
     g = openmc.Geometry([openmc.Cell(region=-cyl)])
@@ -41,6 +60,7 @@ def test_cylinder(request, run_in_tmpdir):
     diff_gold_file('cylinder.jou')
 
 
+@reset_openmc_ids
 def test_x_cone(request, run_in_tmpdir):
     x_cone = openmc.XCone(x0=30.0, y0=3.0, z0=5.0, r2=5.0)
     g = openmc.Geometry([openmc.Cell(region=-x_cone)])
@@ -48,6 +68,7 @@ def test_x_cone(request, run_in_tmpdir):
     diff_gold_file('x_cone.jou')
 
 
+@reset_openmc_ids
 def test_y_cone(request, run_in_tmpdir):
     y_cone = openmc.YCone(x0=40.0, y0=20.0, z0=7.0, r2=2.0)
     g = openmc.Geometry([openmc.Cell(region=-y_cone)])
@@ -55,6 +76,7 @@ def test_y_cone(request, run_in_tmpdir):
     diff_gold_file('y_cone.jou')
 
 
+@reset_openmc_ids
 def test_z_cone(request, run_in_tmpdir):
     z_cone = openmc.ZCone(x0=50.0, y0=10.0, z0=2.0, r2=1.0)
     g = openmc.Geometry([openmc.Cell(region=-z_cone)])
@@ -62,6 +84,7 @@ def test_z_cone(request, run_in_tmpdir):
     diff_gold_file('z_cone.jou')
 
 
+@reset_openmc_ids
 def test_x_torus(request, run_in_tmpdir):
     x_torus = openmc.XTorus(x0=10.0, y0=10.0, z0=10.0, a=5.0, b=2.0, c=2.0)
     g = openmc.Geometry([openmc.Cell(region=-x_torus)])
@@ -69,6 +92,7 @@ def test_x_torus(request, run_in_tmpdir):
     diff_gold_file('x_torus.jou')
 
 
+@reset_openmc_ids
 def test_y_torus(request, run_in_tmpdir):
     y_torus = openmc.YTorus(x0=-10.0, y0=-10.0, z0=-10.0, a=5.0, b=2.0, c=2.0)
     g = openmc.Geometry([openmc.Cell(region=-y_torus)])
@@ -76,6 +100,7 @@ def test_y_torus(request, run_in_tmpdir):
     diff_gold_file('y_torus.jou')
 
 
+@reset_openmc_ids
 def test_z_torus(request, run_in_tmpdir):
     z_torus = openmc.ZTorus(x0=50.0, y0=50.0, z0=50.0, a=5.0, b=2.0, c=2.0)
     g = openmc.Geometry([openmc.Cell(region=-z_torus)])
@@ -83,6 +108,7 @@ def test_z_torus(request, run_in_tmpdir):
     diff_gold_file('z_torus.jou')
 
 
+@reset_openmc_ids
 def test_torus_diff_radii(request, run_in_tmpdir):
     with pytest.raises(ValueError):
         z_torus = openmc.ZTorus(x0=50.0, y0=50.0, z0=50.0, a=5.0, b=2.0, c=3.0)
@@ -90,6 +116,7 @@ def test_torus_diff_radii(request, run_in_tmpdir):
         to_cubit_journal(g, world=(500, 500, 500), filename='a_torus.jou')
 
 
+@reset_openmc_ids
 def test_general_cone(request, run_in_tmpdir):
     with pytest.raises(NotImplementedError):
         cone = openmc.Cone(x0=0.0, y0=0.0, z0=0.0, r2=6.0, dx=1, dy=1, dz=1)

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -12,9 +12,9 @@ def diff_files(test_output, gold_file):
         shutil.copy(test_output, gold_file)
 
     if not filecmp.cmp(test_output, gold_file):
-        print(''.join(difflib.unified_diff(open(test_output, 'r').readlines(),
-                                           open(gold_file, 'r').readlines())))
-        raise RuntimeError(f'{test_output} and {gold_file} are different')
+        print(''.join(difflib.unified_diff(open(gold_file, 'r').readlines(),
+                                           open(test_output, 'r').readlines())))
+        raise RuntimeError(f'{gold_file} and {test_output} are different')
 
 
 def diff_gold_file(gold_file, request=None):


### PR DESCRIPTION
This resets the OpenMC IDs between each test in `test_local.py` so they can be executed separately and pass.