### PR TITLE
Cone fix

### DIFF
--- a/src/openmc_cad_adapter/surfaces.py
+++ b/src/openmc_cad_adapter/surfaces.py
@@ -307,7 +307,7 @@ class CADXCone(CADSurface, openmc.XCone):
 
     def to_cubit_surface_inner(self, ent_type, node, extents, inner_world=None, hex=False):
         cad_cmds = []
-        cad_cmds.append( f"create frustum height {extents[0]} radius {math.sqrt(self.coefficients['r2']*extents[0])} top 0")
+        cad_cmds.append( f"create frustum height {extents[0]} radius {math.sqrt(self.coefficients['r2'])*extents[0]} top 0")
         ids = emit_get_last_id( ent_type , cad_cmds)
         cad_cmds.append( f"rotate body {{ {ids} }} about y angle 90")
         if node.side != '-':
@@ -329,7 +329,7 @@ class CADYCone(CADSurface, openmc.YCone):
 
     def to_cubit_surface_inner(self, ent_type, node, extents, inner_world=None, hex=False):
         cad_cmds = []
-        cad_cmds.append( f"create frustum height {extents[1]} radius {math.sqrt(self.coefficients['r2']*extents[1])} top 0")
+        cad_cmds.append( f"create frustum height {extents[1]} radius {math.sqrt(self.coefficients['r2'])*extents[1]} top 0")
         ids = emit_get_last_id(ent_type, cad_cmds)
         cad_cmds.append( f"rotate body {{ {ids} }} about x angle 90")
         if node.side != '-':
@@ -351,16 +351,20 @@ class CADZCone(CADSurface, openmc.ZCone):
 
     def to_cubit_surface_inner(self, ent_type, node, extents, inner_world=None, hex=False):
         cad_cmds = []
-        cad_cmds.append( f"create frustum height {extents[2]} radius {math.sqrt(self.coefficients['r2']*extents[2])} top 0")
+        cad_cmds.append( f"create frustum height {extents[2]} radius {math.sqrt(self.coefficients['r2'])*extents[2]} top 0")
         ids = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"body {{ {ids} }} move 0 0 -{extents[2]/2.0}")
+        cad_cmds.append(f"body {{ {ids} }} copy reflect z")
+        ids2 = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"unite body {{ {ids} }}  {{ {ids2} }}")
+        x0, y0, z0 = self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0']
+        cad_cmds.append(f"body {{ {ids} }} move {x0} {y0} {z0}")
+
         if node.side != '-':
             cad_cmds.append( f"brick x {extents[0]} y {extents[1]} z {extents[2]}" )
             wid = emit_get_last_id(ent_type , cad_cmds)
             cad_cmds.append(f"subtract body {{ {ids} }} from body {{ {wid} }}")
-            move(wid, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
             ids = wid
-        else:
-            move(ids, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
         return ids, cad_cmds
 
     @classmethod

--- a/src/openmc_cad_adapter/surfaces.py
+++ b/src/openmc_cad_adapter/surfaces.py
@@ -307,17 +307,21 @@ class CADXCone(CADSurface, openmc.XCone):
 
     def to_cubit_surface_inner(self, ent_type, node, extents, inner_world=None, hex=False):
         cad_cmds = []
-        cad_cmds.append( f"create frustum height {extents[0]} radius {math.sqrt(self.coefficients['r2'])*extents[0]} top 0")
-        ids = emit_get_last_id( ent_type , cad_cmds)
-        cad_cmds.append( f"rotate body {{ {ids} }} about y angle 90")
+        cad_cmds.append( f"create frustum height {extents[1]} radius {math.sqrt(self.coefficients['r2'])*extents[1]} top 0")
+        ids = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"body {{ {ids} }} move 0 0 -{extents[1]/2.0}")
+        cad_cmds.append(f"body {{ {ids} }} copy reflect z")
+        ids2 = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"unite body {{ {ids} }}  {{ {ids2} }}")
+        cad_cmds.append( f"rotate body {{ {ids} }} about x angle 90")
+        x0, y0, z0 = self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0']
+        cad_cmds.append(f"body {{ {ids} }} move {x0} {y0} {z0}")
+
         if node.side != '-':
             cad_cmds.append( f"brick x {extents[0]} y {extents[1]} z {extents[2]}" )
-            wid = emit_get_last_id( ent_type , cad_cmds)
+            wid = emit_get_last_id(ent_type , cad_cmds)
             cad_cmds.append(f"subtract body {{ {ids} }} from body {{ {wid} }}")
-            move(wid, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
             ids = wid
-        else:
-            move(ids, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
         return ids, cad_cmds
 
     @classmethod
@@ -331,15 +335,19 @@ class CADYCone(CADSurface, openmc.YCone):
         cad_cmds = []
         cad_cmds.append( f"create frustum height {extents[1]} radius {math.sqrt(self.coefficients['r2'])*extents[1]} top 0")
         ids = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"body {{ {ids} }} move 0 0 -{extents[1]/2.0}")
+        cad_cmds.append(f"body {{ {ids} }} copy reflect z")
+        ids2 = emit_get_last_id(ent_type, cad_cmds)
+        cad_cmds.append(f"unite body {{ {ids} }}  {{ {ids2} }}")
         cad_cmds.append( f"rotate body {{ {ids} }} about x angle 90")
+        x0, y0, z0 = self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0']
+        cad_cmds.append(f"body {{ {ids} }} move {x0} {y0} {z0}")
+
         if node.side != '-':
             cad_cmds.append( f"brick x {extents[0]} y {extents[1]} z {extents[2]}" )
-            wid = emit_get_last_id(ent_type, cad_cmds)
+            wid = emit_get_last_id(ent_type , cad_cmds)
             cad_cmds.append(f"subtract body {{ {ids} }} from body {{ {wid} }}")
-            move(wid, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
             ids = wid
-        else:
-            move(ids, self.coefficients['x0'], self.coefficients['y0'], self.coefficients['z0'], cad_cmds)
         return ids, cad_cmds
 
     @classmethod


### PR DESCRIPTION
The generation of cones from CSG is not currently correct. Only single sided cones are created, but in OpenMC Cone surfaces are double sided by nature. The aperture value is not quite correct, and the move/rotate commands are not in the right order either. 